### PR TITLE
Sync with ex_ncurses changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,39 +2,26 @@
 
   [http://elixirsips.com/episodes/062_quickie_synth.html]
 
-# Installation
+# Install and run
 
-Add the ex_ncurses project to your project dependencies in mix.exs:
+QuickieSynth requires `sox` to play the notes. Install it using the package
+manager on your system. For example,
 
-    {:ex_ncurses, git: "https://github.com/jfreeze/ex_ncurses.git"}
+    sudo apt-get install sox
 
-Then, update your project dependencies, compile, build and run the proejct:
+or
+
+    brew install sox
+
+Then, clone this repository and build the project:
 
     mix deps.get
-    mix deps.compile
     mix build
-    ./priv/start
 
-The current Makefile is only tested on OS X. You may need to customize it to build the ExNcurses Nif for your system.
+To start the ncurses UI for QuickieSynth, run:
 
-As long as the nif is found in ex_ncurses/priv, your project should be able to load the nif.
+    mix start
 
-
-Note, you cannot run ex_ncurses using 'iex -S mox'. It must be run as its own application.
-
-# QuickieSynth
-
-An Elixir based synthesizer. To use it, you can run:
-
-    QuickieSynth.Sound.play("C")
-
-If you want ot build a composition, you can do that like so:
-
-    QuickieSynth.Composition.play(100, "ABCCCDDEE")
-
-
-To run the keyboard UI, evaluate the following:
-
-    QuickieSynth.UI.start
-
-Type any key on the bottom two rows of the keyboard to play notes.
+This invokes `QuickieSynth.UI.start`. Type any key on the bottom two rows
+of the keyboard to play notes. Since ncurses takes control over the
+terminal, calling this from `iex -S mix` doesn't work well.

--- a/lib/mix/tasks/build.ex
+++ b/lib/mix/tasks/build.ex
@@ -1,9 +1,0 @@
-defmodule Mix.Tasks.Build do
-  use Mix.Task
-
-  @shortdoc "Build QuickieSynth script"
-  def run(_) do
-    {result, _error_code} = System.cmd("mix", ["escript.build"], stderr_to_stdout: true)
-    Mix.shell.info result
-  end
-end

--- a/lib/quickie_synth/ui.ex
+++ b/lib/quickie_synth/ui.ex
@@ -1,7 +1,7 @@
 defmodule QuickieSynth.UI do
   alias QuickieSynth.Sound
   alias QuickieSynth.KeyboardMap
-  import ExNcurses
+  alias ExNcurses, as: N
 
   def main(_args) do
     start
@@ -10,29 +10,29 @@ defmodule QuickieSynth.UI do
   def start do
     initui()
     loop()
-    ex_endwin()
+    N.endwin()
   end
 
   def initui do
-    ncurses_begin()
-    ex_keypad()      # Enable support of Function Keys
-    ex_flushinp()    # clear input
+    N.n_begin()
+    N.keypad()      # Enable support of Function Keys
+    N.flushinp()    # clear input
     clear_key_note()
   end
 
   def clear_key_note() do
-    ex_mvprintw(11, 10, "F1 to exit")
-    ex_mvprintw(10, 10, "note:   ")
-    ex_mvprintw( 9, 10, "key:    ")
-    ex_mvprintw( 9, 10, "key: ")
+    N.mvprintw(11, 10, "F1 to exit")
+    N.mvprintw(10, 10, "note:   ")
+    N.mvprintw( 9, 10, "key:    ")
+    N.mvprintw( 9, 10, "key: ")
   end
 
   def loop() do
-    ex_noecho()
-    ex_flushinp()
-    ch = getchar()
+    N.noecho()
+    N.flushinp()
+    ch = N.getchar()
     process_char ch
-   if ch != fun(:F1), do: loop()
+   if ch != N.fun(:F1), do: loop()
   end
 
   def process_char(ch) do
@@ -43,11 +43,11 @@ defmodule QuickieSynth.UI do
         clear_key_note()
         :ok
       _ ->
-        ex_mvprintw(9, 10, "key:       ")
-        ex_mvprintw(9, 10, "key:  #{key}")
-        ex_mvprintw(10, 10, "note:        ")
-        ex_mvprintw(10, 10, "note: #{note}")
-        ex_refresh()
+        N.mvprintw(9, 10, "key:       ")
+        N.mvprintw(9, 10, "key:  #{key}")
+        N.mvprintw(10, 10, "note:        ")
+        N.mvprintw(10, 10, "note: #{note}")
+        N.refresh()
         spawn(Sound, :play, [note])
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -7,10 +7,6 @@ defmodule QuickieSynth.Mixfile do
      elixir: "~> 1.1",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     escript: [
-       main_module: QuickieSynth.UI,
-       path: "priv/start"
-     ],
 
      deps: deps]
   end


### PR DESCRIPTION
This PR brings this example ncurses project up to date with the latest changes to ex_ncurses. The main changes were to remove the escript (can't bundle the shared library) and to not pull in ex_ncurses via an import (doesn't work well with @on_load in ExNcurses). I also made a few documentation updates.
