### PR TITLE
Create an OTP Application and Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ or
 Then, clone this repository and build the project:
 
     mix deps.get
-    mix build
+    mix release
 
 To start the ncurses UI for QuickieSynth, run:
 
-    mix start
+    rel/quickie_synth/bin/quickie_synth foreground
 
-This invokes `QuickieSynth.UI.start`. Type any key on the bottom two rows
-of the keyboard to play notes. Since ncurses takes control over the
-terminal, calling this from `iex -S mix` doesn't work well.
+This starts the `QuickieSynth` application and the `QuickieSynth.UI` `GenServer`.
+Type any key on the bottom two rows of the keyboard to play notes. Since ncurses
+takes control over the terminal, calling this from `iex -S mix` or starting a
+console on the release doesn't work.

--- a/lib/mix/tasks/start.ex
+++ b/lib/mix/tasks/start.ex
@@ -1,8 +1,0 @@
-defmodule Mix.Tasks.Start do
-  use Mix.Task
-
-  @shortdoc "Run UI.start"
-  def run(_) do
-    QuickieSynth.UI.start
-  end
-end

--- a/lib/quickie_synth.ex
+++ b/lib/quickie_synth.ex
@@ -1,2 +1,16 @@
 defmodule QuickieSynth do
+  use Application
+
+  def start(_type, _args) do
+    import Supervisor.Spec
+
+    children = [
+      worker(QuickieSynth.UI, []),
+    ]
+
+    # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: QuickieSynth.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
 end

--- a/lib/quickie_synth/ui.ex
+++ b/lib/quickie_synth/ui.ex
@@ -1,41 +1,56 @@
 defmodule QuickieSynth.UI do
+  use GenServer
+
   alias QuickieSynth.Sound
   alias QuickieSynth.KeyboardMap
   alias ExNcurses, as: N
 
-  def main(_args) do
-    start
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, [], opts)
   end
 
-  def start do
-    initui()
-    loop()
-    N.endwin()
-  end
-
-  def initui do
+  def init(_) do
     N.n_begin()
     N.keypad()      # Enable support of Function Keys
     N.flushinp()    # clear input
     clear_key_note()
+
+    :timer.send_interval(50, :poll)
+    {:ok, 0}
   end
 
-  def clear_key_note() do
+  def handle_info(:poll, state) do
+    N.noecho()
+    N.flushinp()
+    ch = N.getchar()
+    process_char(ch)
+    if ch != N.fun(:F1) do
+      {:noreply, state}
+    else
+      {:stop, :normal}
+    end
+  end
+
+  def terminate(:normal, _state) do
+    N.endwin()
+
+    # If done, quit Elixir too
+    System.halt
+  end
+  def terminate(_reason, _state) do
+    # If terminating unexpectedly, reset ncurses and
+    # let the supervisor restart us
+    N.endwin()
+  end
+
+  defp clear_key_note() do
     N.mvprintw(11, 10, "F1 to exit")
     N.mvprintw(10, 10, "note:   ")
     N.mvprintw( 9, 10, "key:    ")
     N.mvprintw( 9, 10, "key: ")
   end
 
-  def loop() do
-    N.noecho()
-    N.flushinp()
-    ch = N.getchar()
-    process_char ch
-   if ch != N.fun(:F1), do: loop()
-  end
-
-  def process_char(ch) do
+  defp process_char(ch) do
     key = List.to_string([ch])
     note = KeyboardMap.note_for(key)
     case note do
@@ -51,5 +66,4 @@ defmodule QuickieSynth.UI do
         spawn(Sound, :play, [note])
     end
   end
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,8 @@ defmodule QuickieSynth.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [mod: {QuickieSynth, []},
+     applications: [:ex_ncurses]]
   end
 
   # Dependencies can be Hex packages:
@@ -29,7 +30,8 @@ defmodule QuickieSynth.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:ex_ncurses, git: "https://github.com/jfreeze/ex_ncurses.git"}
+      {:ex_ncurses, git: "https://github.com/jfreeze/ex_ncurses.git"},
+      {:exrm, "~> 1.0.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,9 @@
-%{"ex_ncurses": {:git, "https://github.com/jfreeze/ex_ncurses.git", "bb01e4a19b697aeba8d031d0baa99e73a374441d", []}}
+%{"bbmustache": {:hex, :bbmustache, "1.0.4", "7ba94f971c5afd7b6617918a4bb74705e36cab36eb84b19b6a1b7ee06427aa38", [:rebar], []},
+  "cf": {:hex, :cf, "0.2.1", "69d0b1349fd4d7d4dc55b7f407d29d7a840bf9a1ef5af529f1ebe0ce153fc2ab", [:rebar3], []},
+  "elixir_make": {:hex, :elixir_make, "0.3.0", "285147fa943806eee82f6680b7b446b5569bcf3ee8328fa0a7c200ffc44fbaba", [:mix], []},
+  "erlware_commons": {:hex, :erlware_commons, "0.21.0", "a04433071ad7d112edefc75ac77719dd3e6753e697ac09428fc83d7564b80b15", [:rebar3], [{:cf, "0.2.1", [hex: :cf, optional: false]}]},
+  "ex_ncurses": {:git, "https://github.com/jfreeze/ex_ncurses.git", "303954b2debec4b481302215017c6fbc3693772f", []},
+  "exrm": {:hex, :exrm, "1.0.6", "f708fc091dcacb93c1da58254a1ab34166d5ac3dca162877e878fe5d7a9e9dce", [:mix], [{:relx, "~> 3.5", [hex: :relx, optional: false]}]},
+  "getopt": {:hex, :getopt, "0.8.2", "b17556db683000ba50370b16c0619df1337e7af7ecbf7d64fbf8d1d6bce3109b", [:rebar], []},
+  "providers": {:hex, :providers, "1.6.0", "db0e2f9043ae60c0155205fcd238d68516331d0e5146155e33d1e79dc452964a", [:rebar3], [{:getopt, "0.8.2", [hex: :getopt, optional: false]}]},
+  "relx": {:hex, :relx, "3.20.0", "b515b8317d25b3a1508699294c3d1fa6dc0527851dffc87446661bce21a36710", [:rebar3], [{:providers, "1.6.0", [hex: :providers, optional: false]}, {:getopt, "0.8.2", [hex: :getopt, optional: false]}, {:erlware_commons, "0.21.0", [hex: :erlware_commons, optional: false]}, {:cf, "0.2.1", [hex: :cf, optional: false]}, {:bbmustache, "1.0.4", [hex: :bbmustache, optional: false]}]}}


### PR DESCRIPTION
I'd like to propose moving the example towards showing how to use ex_ncurses in a `GenServer`. While `ex_ncurses` doesn't support it yet, it would be nice to receive keyboard input via messages. Likewise, sending messages from other processes to a UI `GenServer` feels the the right structure for non-trivial applications. Fwiw, I still like the idea of being able to poll for input from simple scripts, so I wouldn't want that feature removed.

This PR also makes `QuickieSynth` an OTP application and adds a supervisor on the UI `GenServer`. This is roughly how I'm using `ex_ncurses` with a Nerves project and I thought that it would be helpful to others. 
